### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ A repo that contains a simple sample application for testing build processes
 .
 .
 .
+.

--- a/README.md
+++ b/README.md
@@ -3,5 +3,3 @@
 A repo that contains a simple sample application for testing build processes 
 .
 .
-.
-.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/richardfennell/670b3a60-2021-47ab-a88b-d76ebd888a2f/7bde3216-5d20-4839-aced-8b708bab0361/_apis/work/boardbadge/5c974029-72e2-435e-b257-9302aecd0591)](https://dev.azure.com/richardfennell/670b3a60-2021-47ab-a88b-d76ebd888a2f/_boards/board/t/7bde3216-5d20-4839-aced-8b708bab0361/Microsoft.RequirementCategory)
 # SampleRepo
 A repo that contains a simple sample application for testing build processes 
 .


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#68](https://dev.azure.com/richardfennell/670b3a60-2021-47ab-a88b-d76ebd888a2f/_workitems/edit/68). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.